### PR TITLE
reader: add # for "swap" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ values (when appropriate).  The REPL will always print the value
 returned by the last command.
 
 The `@` command duplicates the value at the top of the stack and
-pushes the duplicate.  The `$` command will push a `nil`.
+pushes the duplicate.  The `$` command will push a `nil`.  The
+`#` command swaps the two elements at the top of the stack.
 
 To push an element onto the stack, use the `push` command.  To
 pop the top element, one may use the `pop` command.  Note also
@@ -95,6 +96,8 @@ equivalent to:
 rz | @inflate | mount | load /platform/oxide/kernel/amd64/unix | call
 ```
 
+## Commands
+
 The reader supports a handful of "reader commands":
 
 * `clear` clears the terminal window
@@ -126,6 +129,10 @@ Supported commands include:
   entry point.
 * `loadmem <addr>,<len>` to load an ELF object from the given
   region of memory.
+* `call <location> [<up to 6 args>]` calls the System V ABI
+  compliant function at `<location>`, passing up to six
+  arguments taken from the environment stack argument list
+  terminated by nil.
 * `rdmsr <u32>` to read the numbered MSR (note some MSRs can be
   specified by name, such as `IA32_APIC_BASE`).
 * `wrmsr <u32> <u64>` to write the given value to the given MSR.


### PR DESCRIPTION
Add a reader token that will swap the top two
elements on the stack, which means we can do things
like this:

    wrsmn # . setbits 1,4 0b101 . rdsmn @0x1230_0000

Which will,

1. Push 0x12300000 onto the stack
2. Duplicate it so that the stack has two copies
   of 0x12300000
3. Call `rdsmn` which will pop the first copy and read whatever
   is at that SMN address (this is just an example; assume it is
   a valid SMN address) and push it onto the stack.  The stack
   now contains the value it read via SMN, as well as the
   `0x1230_000` pushed earlier
4. Push 0b101, 1,4 and invoke setbits, which will pop the first
   three values (1,4, 0b101 and the contents of the SMN register
   read a moment ago).  Set bits will set bits 1..=3 in the SMN
   value to `101` and push that onto the stack.  The stack now
   contains the modified SMN value and 0x12300000.
5. Swap the top two elements of the stack, so that it now
   contains the SMN address at the top, then the modified value
6. Invoke `wrsmn` which will pop the address and value, and
   write the value to that SMN address.

And we're done.  This may be clearer using the `|` syntax:

    rdsmn @0x1230_0000 | setbits 1,4 0b101 | wrsmn #

Signed-off-by: Dan Cross <cross@oxidecomputer.com>
