### PR TITLE
zoxboot: an alias for the most common boot case

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ will pop the top element.
 
 ## Booting a machine
 
+In the simplest case, run `zoxboot` and send your ramdisk via
+ZMODEM.  `zoxboot` is an alias that expands to to the command
+line below.
+
 Assuming you have booted into `bldb` on some machine of
 interest, you will be presented with a prompt (`@`), at which
 you may type commands.  To send a compressed ramdisk, inflate

--- a/src/bldb.rs
+++ b/src/bldb.rs
@@ -45,9 +45,12 @@ use crate::iomux;
 use crate::mem;
 use crate::mmu;
 use crate::ramdisk;
+use crate::repl;
 use crate::result::Error;
 use crate::uart::{self, Uart};
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
 use core::fmt;
 use core::ops::Range;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -64,6 +67,7 @@ pub(crate) struct Config {
     pub(crate) page_table: mmu::LoaderPageTable,
     pub(crate) ramdisk: Option<Box<dyn ramdisk::FileSystem>>,
     pub(crate) prompt: cons::Prompt,
+    pub(crate) aliases: BTreeMap<String, String>,
 }
 
 impl Config {
@@ -134,6 +138,9 @@ pub(crate) unsafe extern "C" fn init(bist: u32) -> &'static mut Config {
         iomux_region,
         gpio_region,
     ];
+    let aliases = BTreeMap::from_iter(
+        repl::DEF_ALIASES.iter().map(|&(k, v)| (k.into(), v.into())),
+    );
     let mut config = Box::new(Config {
         cons,
         iomux,
@@ -146,6 +153,7 @@ pub(crate) unsafe extern "C" fn init(bist: u32) -> &'static mut Config {
         ),
         ramdisk: None,
         prompt: cons::DEFAULT_PROMPT,
+        aliases,
     });
     if false {
         say_hi_sp(&mut config, 4);

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -39,6 +39,11 @@ mod sha;
 mod smn;
 mod vm;
 
+pub const DEF_ALIASES: &[(&str, &str)] = &[(
+    "zoxboot",
+    "call . load /platform/oxide/kernel/amd64/unix . mount . @inflate . rz",
+)];
+
 #[derive(Clone)]
 #[allow(dead_code)]
 enum Value {

--- a/src/repl/reader.rs
+++ b/src/repl/reader.rs
@@ -199,6 +199,9 @@ pub fn read(
         if eval_reader_command(config, line, env, lastval) {
             continue;
         }
+        if let Some(expansion) = config.aliases.get(line) {
+            break expansion.clone();
+        }
         break s;
     };
     let mut cmds = Vec::<Command>::new();
@@ -311,6 +314,10 @@ Pushes the strings "a", "b", and "c" onto the stack, while,
 will pop the top element.
 
 ## Booting a machine
+
+In the simplest case, run `zoxboot` and send your ramdisk via
+ZMODEM.  `zoxboot` is an alias that expands to to the command
+line below.
 
 To send a compressed ramdisk, inflate it, mount it, load a
 kernel from it, and call into that kernel, passing the ramdisk


### PR DESCRIPTION
Add the skeleton of an alias system, and provide a default for the most common case of booting a machine with a ramdisk sent via ZMODEM.  With this change, the single command `zoxboot` will automatically receive a compressed ramdisk (either UFS or a cpio miniroot), expand it, mount it, load our kernel nucleus from it, and call the kernel's entry point.

Tested on Garnet.