### PR TITLE
repl: support `b` and `h` suffices for bin/hex

### DIFF
--- a/src/repl/reader.rs
+++ b/src/repl/reader.rs
@@ -46,8 +46,11 @@ pub(super) fn parse_num<T: Default + TryFrom<u128>>(num: &str) -> Result<T> {
     let (radix, numstr) = match num {
         "0" => return Ok(T::default()),
         s if s.starts_with("0x") || s.starts_with("0X") => (16, &s[2..]),
+        s if s.ends_with("h") || s.ends_with("H") => (16, &s[..s.len() - 1]),
         s if s.starts_with("0t") || s.starts_with("0T") => (10, &s[2..]),
         s if s.starts_with("0b") || s.starts_with("0B") => (2, &s[2..]),
+        s if s.starts_with("0i") || s.starts_with("0I") => (2, &s[2..]),
+        s if s.ends_with("b") || s.ends_with("B") => (2, &s[..s.len() - 1]),
         s if s.starts_with("0") => (8, &s[0..]),
         s => (10, s),
     };


### PR DESCRIPTION
Support the syntax like `1010b` and `12c3h` for binary and hex, respectively.  These formats are common in AMD documentation.